### PR TITLE
Enhance responsiveness

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -43,6 +43,7 @@ jobs:
           paths:
             - .circleci
             - .credo.exs
+            - .dialyzer-ignore
             - .formatter.exs
             - .git
             - .gitignore

--- a/.formatter.exs
+++ b/.formatter.exs
@@ -1,4 +1,5 @@
 # Used by "mix format"
 [
-  inputs: ["{mix,.formatter}.exs", "{config,lib,test}/**/*.{ex,exs}"]
+  inputs: ["{mix,.formatter}.exs", "{config,lib,test}/**/*.{ex,exs}"],
+  line_length: 120
 ]

--- a/lib/moddity.ex
+++ b/lib/moddity.ex
@@ -1,2 +1,3 @@
 defmodule Moddity do
+  @moduledoc false
 end

--- a/lib/moddity/backend.ex
+++ b/lib/moddity/backend.ex
@@ -1,11 +1,25 @@
 defmodule Moddity.Backend do
+  @moduledoc """
+  This module defines the low-level behaviors that a Backend should implement
+  """
+
   @doc """
   Gets the status from the backend printer
   """
   @callback get_status() :: {:ok, map()} | {:error, any()}
 
   @doc """
+  Sends the load filament command to the printer
+  """
+  @callback load_filament() :: :ok | {:error, any()}
+
+  @doc """
   sends the given gcode file to the printer for printing
   """
   @callback send_gcode(binary()) :: :ok | {:error, any()}
+
+  @doc """
+  Sends the unload filament command to the printer
+  """
+  @callback unload_filament() :: :ok | {:error, any()}
 end

--- a/lib/moddity/backend.ex
+++ b/lib/moddity/backend.ex
@@ -1,0 +1,11 @@
+defmodule Moddity.Backend do
+  @doc """
+  Gets the status from the backend printer
+  """
+  @callback get_status() :: {:ok, map()} | {:error, any()}
+
+  @doc """
+  sends the given gcode file to the printer for printing
+  """
+  @callback send_gcode(binary()) :: :ok | {:error, any()}
+end

--- a/lib/moddity/backend/python_shell.ex
+++ b/lib/moddity/backend/python_shell.ex
@@ -16,13 +16,13 @@ defmodule Moddity.Backend.PythonShell do
       {:ok, parsed_response}
     else
       {error, 1} ->
-        {:error, error}
-
-      {:error, error} ->
         case Regex.match?(~r/Device not found/, error) do
-          true -> {:error, "Device not found"}
-          false -> {:error, "Unknown Error"}
+          true -> {:error, "Device Not Found"}
+          false -> {:error, error}
         end
+
+      {:error, error = %Jason.DecodeError{}} ->
+        {:error, "Problem parsing printer response: #{inspect(error)}"}
 
       error ->
         {:error, error}

--- a/lib/moddity/backend/python_shell.ex
+++ b/lib/moddity/backend/python_shell.ex
@@ -1,17 +1,20 @@
 defmodule Moddity.Backend.PythonShell do
   def get_status do
     modt_status = Path.join([priv_dir(), "mod-t-scripts", "modt_status.py"])
+
     with {response, 0} <- System.cmd("python3", [modt_status]),
          {:ok, parsed_response} <- Jason.decode(response) do
-
       {:ok, parsed_response}
     else
-      {error, 1} -> {:error, error}
+      {error, 1} ->
+        {:error, error}
+
       {:error, error} ->
         case Regex.match?(~r/Device not found/, error) do
           true -> {:error, "Device not found"}
           false -> {:error, "Unknown Error"}
         end
+
       error ->
         {:error, error}
     end
@@ -42,7 +45,7 @@ defmodule Moddity.Backend.PythonShell do
     unload_filament_script = Path.join([priv_dir(), "mod-t-scripts", "unload_filament.py"])
 
     with {response, 0} <- System.cmd("python3", [unload_filament_script]) do
-      IO.inspect response
+      IO.inspect(response)
       :ok
     else
       error -> {:error, error}

--- a/lib/moddity/backend/python_shell.ex
+++ b/lib/moddity/backend/python_shell.ex
@@ -1,4 +1,13 @@
 defmodule Moddity.Backend.PythonShell do
+  @moduledoc """
+  This module is a shim to the python scripts that communicate with the printer.
+  """
+
+  alias Moddity.Backend
+
+  @behaviour Backend
+
+  @impl Backend
   def get_status do
     modt_status = Path.join([priv_dir(), "mod-t-scripts", "modt_status.py"])
 
@@ -20,6 +29,7 @@ defmodule Moddity.Backend.PythonShell do
     end
   end
 
+  @impl Backend
   def load_filament do
     load_filament_script = Path.join([priv_dir(), "mod-t-scripts", "load_filament.py"])
 
@@ -30,6 +40,7 @@ defmodule Moddity.Backend.PythonShell do
     end
   end
 
+  @impl Backend
   def send_gcode(file) do
     send_gcode = Path.join([priv_dir(), "mod-t-scripts", "send_gcode.py"])
 
@@ -41,11 +52,11 @@ defmodule Moddity.Backend.PythonShell do
     end
   end
 
+  @impl Backend
   def unload_filament do
     unload_filament_script = Path.join([priv_dir(), "mod-t-scripts", "unload_filament.py"])
 
     with {response, 0} <- System.cmd("python3", [unload_filament_script]) do
-      IO.inspect(response)
       :ok
     else
       error -> {:error, error}

--- a/lib/moddity/backend/python_shell.ex
+++ b/lib/moddity/backend/python_shell.ex
@@ -1,0 +1,55 @@
+defmodule Moddity.Backend.PythonShell do
+  def get_status do
+    modt_status = Path.join([priv_dir(), "mod-t-scripts", "modt_status.py"])
+    with {response, 0} <- System.cmd("python3", [modt_status]),
+         {:ok, parsed_response} <- Jason.decode(response) do
+
+      {:ok, parsed_response}
+    else
+      {error, 1} -> {:error, error}
+      {:error, error} ->
+        case Regex.match?(~r/Device not found/, error) do
+          true -> {:error, "Device not found"}
+          false -> {:error, "Unknown Error"}
+        end
+      error ->
+        {:error, error}
+    end
+  end
+
+  def load_filament do
+    load_filament_script = Path.join([priv_dir(), "mod-t-scripts", "load_filament.py"])
+
+    with {response, 0} <- System.cmd("python3", [load_filament_script]) do
+      :ok
+    else
+      error -> {:error, error}
+    end
+  end
+
+  def send_gcode(file) do
+    send_gcode = Path.join([priv_dir(), "mod-t-scripts", "send_gcode.py"])
+
+    with {response, 0} <- System.cmd("python3", [send_gcode, file]),
+         {:ok, parsed_response} <- Jason.decode(response) do
+      :ok
+    else
+      error -> {:error, error}
+    end
+  end
+
+  def unload_filament do
+    unload_filament_script = Path.join([priv_dir(), "mod-t-scripts", "unload_filament.py"])
+
+    with {response, 0} <- System.cmd("python3", [unload_filament_script]) do
+      IO.inspect response
+      :ok
+    else
+      error -> {:error, error}
+    end
+  end
+
+  defp priv_dir do
+    priv_dir = :code.priv_dir(:moddity)
+  end
+end

--- a/lib/moddity/driver.ex
+++ b/lib/moddity/driver.ex
@@ -10,7 +10,7 @@ defmodule Moddity.Driver do
   use GenServer
 
   @timeout 60_000
-  @default_backend Moddity.PythonShellBackend
+  @default_backend Moddity.Backend.PythonShell
 
   defstruct []
 

--- a/lib/moddity/driver.ex
+++ b/lib/moddity/driver.ex
@@ -1,4 +1,12 @@
 defmodule Moddity.Driver do
+  @moduledoc """
+  This module is the entrypoint for communication with a MOD-t printer.
+
+  It maintains communication state and manages some primitive caching and
+  handles returning last known state when another process is sending a command
+  to the printer.
+  """
+
   use GenServer
 
   @timeout 60_000

--- a/lib/moddity/driver.ex
+++ b/lib/moddity/driver.ex
@@ -2,87 +2,68 @@ defmodule Moddity.Driver do
   use GenServer
 
   @timeout 60_000
+  @default_backend Moddity.PythonShellBackend
 
   defstruct []
 
   def start_link(opts) do
-    GenServer.start_link(__MODULE__, :ok, name: __MODULE__)
+    name = Keyword.get(opts, :name, __MODULE__)
+    GenServer.start_link(__MODULE__, opts, name: name)
   end
 
-  def init(_) do
-    {:ok, %{}}
+  def init(opts) do
+    backend = Keyword.get(opts, :backend, @default_backend)
+    {:ok, %{backend: backend, last_status: nil}}
   end
 
-  def get_status do
-    GenServer.call(__MODULE__, {:get_status}, @timeout)
+  def get_status(opts \\ []) do
+    pid = Keyword.get(opts, :pid, __MODULE__)
+    GenServer.call(pid, {:get_status}, @timeout)
   end
 
-  def load_filament do
-    GenServer.call(__MODULE__, {:load_filament}, @timeout)
+  def load_filament(opts \\ []) do
+    pid = Keyword.get(opts, :pid, __MODULE__)
+    GenServer.call(pid, {:load_filament}, @timeout)
   end
 
-  def send_gcode(file) do
-    GenServer.call(__MODULE__, {:send_gcode, file}, @timeout)
+  def send_gcode(file, opts \\ []) do
+    pid = Keyword.get(opts, :pid, __MODULE__)
+    GenServer.call(pid, {:send_gcode, file}, @timeout)
   end
 
-  def unload_filament do
-    GenServer.call(__MODULE__, {:unload_filament}, @timeout)
+  def unload_filament(opts \\ []) do
+    pid = Keyword.get(opts, :pid, __MODULE__)
+    GenServer.call(pid, {:unload_filament}, @timeout)
   end
 
   def handle_call({:get_status}, _from, state) do
-    modt_status = Path.join([priv_dir(), "mod-t-scripts", "modt_status.py"])
-    with {response, 0} <- System.cmd("python3", [modt_status]),
-         {:ok, parsed_response} <- Jason.decode(response) do
-
-      {:reply, {:ok, parsed_response}, parsed_response}
-    else
-      {error, 1} ->
-        {:reply, {:error, error}, state}
-      {:error, error} ->
-        case Regex.match?(~r/Device not found/, error) do
-          true -> {:reply, {:error, "Device not found"}, state}
-          false -> {:reply, {:error, "Unknown Error"}, state}
-        end
-      error ->
-        IO.inspect error
-        {:reply, {:error, error}, state}
+    case state.backend.get_status do
+      {:ok, status} -> {:reply, {:ok, status}, %{state | last_status: status}}
+      {:error, error} -> {:reply, {:error, error}, state}
     end
   end
 
   def handle_call({:load_filament}, _from, state) do
-    load_filament_script = Path.join([priv_dir(), "mod-t-scripts", "load_filament.py"])
-
-    with {response, 0} <- System.cmd("python3", [load_filament_script]) do
-      IO.inspect response
-      {:reply, :ok, state}
-    else
-      error -> {:reply, {:error, error}, state}
+    case state.backend.load_filament do
+      :ok -> {:reply, :ok, state}
+      {:error, error} -> {:reply, {:error, error}, state}
     end
   end
 
-  def handle_call({:send_gcode, file}, _from, state) do
-    send_gcode = Path.join([priv_dir(), "mod-t-scripts", "send_gcode.py"])
-
-    with {response, 0} <- System.cmd("python3", [send_gcode, file]),
-         {:ok, parsed_response} <- Jason.decode(response) do
-      {:reply, :ok, state}
-    else
-      error -> {:reply, {:error, error}, state}
-    end
+  def handle_call({:send_gcode, file}, from, state) do
+    Task.async(fn -> state.backend.send_gcode(file) end)
+    {:noreply, Map.merge(state, %{from: from})}
   end
 
   def handle_call({:unload_filament}, _from, state) do
-    unload_filament_script = Path.join([priv_dir(), "mod-t-scripts", "unload_filament.py"])
-
-    with {response, 0} <- System.cmd("python3", [unload_filament_script]) do
-      IO.inspect response
-      {:reply, :ok, state}
-    else
-      error -> {:reply, {:error, error}, state}
+    case state.backend.unload_filament do
+      :ok -> {:reply, :ok, state}
+      {:error, error} -> {:reply, {:error, error}, state}
     end
   end
 
-  defp priv_dir do
-    priv_dir = :code.priv_dir(:moddity)
+  def handle_info({sender, response}, state) do
+    GenServer.reply(state.from, response)
+    {:noreply, Map.delete(state, :from)}
   end
 end

--- a/lib/moddity/fake_driver.ex
+++ b/lib/moddity/fake_driver.ex
@@ -140,7 +140,7 @@ defmodule Moddity.FakeDriver do
     |> put_in(["status", "extruder_target_temperature"], 200.0)
     |> put_in(["status", "extruder_temperature"], 105.7)
     |> put_in(["status", "state"], "STATE_JOB_QUEUED")
-    |> put_in(["job", "file_size"], 1540647)
+    |> put_in(["job", "file_size"], 1_540_647)
   end
 
   defp state_building do
@@ -150,7 +150,7 @@ defmodule Moddity.FakeDriver do
     |> put_in(["status", "state"], "STATE_BUILDING")
     |> put_in(["job", "current_gcode_number"], 4841)
     |> put_in(["job", "current_line_number"], 4841)
-    |> put_in(["job", "file_size"], 1540647)
+    |> put_in(["job", "file_size"], 1_540_647)
     |> put_in(["job", "progress"], 9)
     |> put_in(["job", "time-elapsed"], 219)
   end
@@ -162,7 +162,7 @@ defmodule Moddity.FakeDriver do
     |> put_in(["status", "state"], "STATE_EXEC_PAUSE_CMD")
     |> put_in(["job", "current_gcode_number"], 5763)
     |> put_in(["job", "current_line_number"], 5763)
-    |> put_in(["job", "file_size"], 1540647)
+    |> put_in(["job", "file_size"], 1_540_647)
     |> put_in(["job", "progress"], 10)
     |> put_in(["job", "time-elapsed"], 290)
   end

--- a/lib/moddity/fake_driver.ex
+++ b/lib/moddity/fake_driver.ex
@@ -1,4 +1,11 @@
 defmodule Moddity.FakeDriver do
+  @moduledoc """
+  This module exists as a fake stand-in for the real driver module.
+
+  It attempts to mimic real printer states based on observation while developing
+  the real driver.
+  """
+
   use GenServer
 
   import Process, only: [{:send_after, 3}]

--- a/lib/moddity/printer_status.ex
+++ b/lib/moddity/printer_status.ex
@@ -1,4 +1,9 @@
 defmodule Moddity.PrinterStatus do
+  @moduledoc """
+  PrinterStatus is a struct to represent the printer's status to clients. It is
+  a sanitized version of the raw json that the printer returns.
+  """
+
   defstruct [
     :error,
     :job_progress,

--- a/lib/moddity/printer_status.ex
+++ b/lib/moddity/printer_status.ex
@@ -4,9 +4,67 @@ defmodule Moddity.PrinterStatus do
     :job_progress,
     :job_time_elapsed,
     :extruder_target_temperature,
-    :extruder_temperature,
+    :extruder_actual_temperature,
     :filament,
     :state,
+    :state_friendly,
+    :state_raw,
     :idle?
   ]
+
+  def from_raw(raw) do
+    state_raw = get_in(raw, ["status", "state"])
+    state = translate_state(state_raw)
+
+    %__MODULE__{
+      state: state,
+      state_friendly: to_human(state_raw),
+      state_raw: get_in(raw, ["status", "state"]),
+      idle?: state == :idle,
+      error: raw["error"],
+      job_progress: get_in(raw, ["job", "progress"]),
+      extruder_target_temperature: get_in(raw, ["status", "extruder_target_temperature"]),
+      extruder_actual_temperature: get_in(raw, ["status", "extruder_temperature"])
+    }
+  end
+
+  defp to_human("STATE_BUILDING"), do: "Building"
+  defp to_human("STATE_EXEC_PAUSE_CMD"), do: "Pausing"
+  defp to_human("STATE_FILE_RX"), do: "Receiving File"
+  defp to_human("STATE_HOMING_HEATING"), do: "Calibrating: Heating"
+  defp to_human("STATE_HOMING_XY"), do: "Calibrating: XY"
+  defp to_human("STATE_HOMING_Z_FINE"), do: "Calibrating: Z (Fine)"
+  defp to_human("STATE_HOMING_Z_ROUGH"), do: "Calibrating: Z (Rough)"
+  defp to_human("STATE_IDLE"), do: "Idle"
+  defp to_human("STATE_JOB_CANCEL"), do: "Job Canceled"
+  defp to_human("STATE_JOB_PREP"), do: "Job Prep"
+  defp to_human("STATE_JOB_QUEUED"), do: "Job Queued"
+  defp to_human("STATE_LOADFIL_EXTRUDING"), do: "Load Filament: Extruding"
+  defp to_human("STATE_LOADFIL_HEATING"), do: "Load Filament: Heating"
+  defp to_human("STATE_MECH_READY"), do: "Mech Ready"
+  defp to_human("STATE_NET_FAILED"), do: "Net Failed"
+  defp to_human("STATE_PAUSED"), do: "Paused"
+  defp to_human("STATE_REMFIL_HEATING"), do: "Unload Filament: Heating"
+  defp to_human("STATE_REMFIL_RETRACTING"), do: "Unload Filament: Retracting"
+  defp to_human(state), do: "Unknown: #{state}"
+
+  defp translate_state("STATE_BUILDING"), do: :building
+  defp translate_state("STATE_EXEC_PAUSE_CMD"), do: :pausing
+  defp translate_state("STATE_FILE_RX"), do: :receiving_file
+  defp translate_state("STATE_HOMING_HEATING"), do: :homing_heating
+  defp translate_state("STATE_HOMING_XY"), do: :homing_xy
+  defp translate_state("STATE_HOMING_Z_FINE"), do: :homing_z_fine
+  defp translate_state("STATE_HOMING_Z_ROUGH"), do: :homing_z_rough
+  defp translate_state("STATE_IDLE"), do: :idle
+  defp translate_state("STATE_JOB_CANCEL"), do: :canceled
+  defp translate_state("STATE_JOB_PREP"), do: :job_prep
+  defp translate_state("STATE_JOB_QUEUED"), do: :job_queued
+  defp translate_state("STATE_LOADFIL_EXTRUDING"), do: :load_filament_extruding
+  defp translate_state("STATE_LOADFIL_HEATING"), do: :load_filament_heating
+  defp translate_state("STATE_MECH_READY"), do: :mech_ready
+  defp translate_state("STATE_NET_FAILED"), do: :net_failed
+  defp translate_state("STATE_PAUSED"), do: :paused
+  defp translate_state("STATE_REMFIL_HEATING"), do: :unload_filament_heating
+  defp translate_state("STATE_REMFIL_RETRACTING"), do: :unload_filament_retracting
+  defp translate_state(_), do: :unknown
 end

--- a/lib/moddity/printer_status.ex
+++ b/lib/moddity/printer_status.ex
@@ -1,0 +1,12 @@
+defmodule Moddity.PrinterStatus do
+  defstruct [
+    :error,
+    :job_progress,
+    :job_time_elapsed,
+    :extruder_target_temperature,
+    :extruder_temperature,
+    :filament,
+    :state,
+    :idle?
+  ]
+end

--- a/mix.exs
+++ b/mix.exs
@@ -38,7 +38,8 @@ defmodule Moddity.MixProject do
       {:credo, "~> 1.0.0", only: [:dev, :test], runtime: false},
       {:dialyxir, "~> 1.0.0-rc.6", only: [:dev, :test], runtime: false},
       {:excoveralls, "~> 0.10", only: :test},
-      {:jason, "~> 1.0"}
+      {:jason, "~> 1.0"},
+      {:mox, "~> 0.5", only: :test}
     ]
   end
 end

--- a/mix.lock
+++ b/mix.lock
@@ -8,6 +8,7 @@
   "hackney": {:hex, :hackney, "1.15.1", "9f8f471c844b8ce395f7b6d8398139e26ddca9ebc171a8b91342ee15a19963f4", [:rebar3], [{:certifi, "2.5.1", [hex: :certifi, repo: "hexpm", optional: false]}, {:idna, "6.0.0", [hex: :idna, repo: "hexpm", optional: false]}, {:metrics, "1.0.1", [hex: :metrics, repo: "hexpm", optional: false]}, {:mimerl, "~>1.1", [hex: :mimerl, repo: "hexpm", optional: false]}, {:ssl_verify_fun, "1.1.4", [hex: :ssl_verify_fun, repo: "hexpm", optional: false]}], "hexpm"},
   "idna": {:hex, :idna, "6.0.0", "689c46cbcdf3524c44d5f3dde8001f364cd7608a99556d8fbd8239a5798d4c10", [:rebar3], [{:unicode_util_compat, "0.4.1", [hex: :unicode_util_compat, repo: "hexpm", optional: false]}], "hexpm"},
   "jason": {:hex, :jason, "1.1.2", "b03dedea67a99223a2eaf9f1264ce37154564de899fd3d8b9a21b1a6fd64afe7", [:mix], [{:decimal, "~> 1.0", [hex: :decimal, repo: "hexpm", optional: true]}], "hexpm"},
+  "mox": {:hex, :mox, "0.5.0", "c519b48407017a85f03407a9a4c4ceb7cc6dec5fe886b2241869fb2f08476f9e", [:mix], [], "hexpm"},
   "metrics": {:hex, :metrics, "1.0.1", "25f094dea2cda98213cecc3aeff09e940299d950904393b2a29d191c346a8486", [:rebar3], [], "hexpm"},
   "mimerl": {:hex, :mimerl, "1.2.0", "67e2d3f571088d5cfd3e550c383094b47159f3eee8ffa08e64106cdf5e981be3", [:rebar3], [], "hexpm"},
   "parse_trans": {:hex, :parse_trans, "3.3.0", "09765507a3c7590a784615cfd421d101aec25098d50b89d7aa1d66646bc571c1", [:rebar3], [], "hexpm"},

--- a/priv/mod-t-scripts/modt_status.py
+++ b/priv/mod-t-scripts/modt_status.py
@@ -25,10 +25,8 @@ dev = usb.core.find(idVendor=0x2b75, idProduct=0x0002, backend=backend)
 
 # was it found?
 if dev is None:
-    raise ValueError('Device not found')
+ print('{"error": "Device not found"}')
+ raise ValueError('Device not found')
 
-#Finally, loop and query mod-t status every 5 seconds
-#while True:
 dev.write(4, '{"metadata":{"version":1,"type":"status"}}')
 print(read_modt(0x83))
-# time.sleep(5)

--- a/test/moddity/driver_test.exs
+++ b/test/moddity/driver_test.exs
@@ -27,14 +27,14 @@ defmodule Moddity.DriverTest do
     allow(Mock, self(), pid)
 
     assert {:ok, idle_status()} == Driver.get_status(pid: pid)
-    :timer.sleep(200)
+    :timer.sleep(50)
     assert {:ok, idle_status()} == Driver.get_status(pid: pid)
   end
 
   test "when send_gcode is being sent, the printer is not idle", %{pid: pid} do
     Mock
     |> expect(:send_gcode, fn _file ->
-      :timer.sleep(1000)
+      :timer.sleep(30)
       :ok
     end)
     |> allow(self(), pid)

--- a/test/moddity/driver_test.exs
+++ b/test/moddity/driver_test.exs
@@ -1,0 +1,40 @@
+defmodule Moddity.DriverTest do
+  use ExUnit.Case, async: true
+
+  import Mox
+
+  alias Moddity.Backend.Mock
+  alias Moddity.Driver
+
+  doctest Moddity.Driver
+
+  setup :verify_on_exit!
+
+  setup do
+    {:ok, pid} = start_supervised({Driver, backend: Mock})
+    {:ok, pid: pid}
+  end
+
+  test "get_status returns the status from the printer", %{pid: pid} do
+    status = {:ok, %{test_status: true}}
+    expect(Mock, :get_status, fn -> status end)
+    allow(Mock, self(), pid)
+
+    assert status == Driver.get_status(pid: pid)
+  end
+
+  test "when send_gcode is executing, the genserver responds to status requests appropriately", %{pid: pid} do
+    status = {:ok, %{thing: :true}}
+
+    Mock
+    |> expect(:get_status, fn -> status end)
+    |> expect(:send_gcode, fn _file -> :timer.sleep(10000)
+      :ok end)
+    |> allow(self(), pid)
+
+    assert status == Driver.get_status(pid: pid)
+    task = Task.async( fn -> assert :ok = Driver.send_gcode("whatever") end)
+    assert {:ok, %{status: "IN_USE"}} == Driver.get_status(pid: pid)
+    Task.await(task, 15_000)
+  end
+end

--- a/test/moddity/printer_status_test.exs
+++ b/test/moddity/printer_status_test.exs
@@ -1,0 +1,209 @@
+defmodule PrinterStatusTest do
+  use ExUnit.Case, async: true
+
+  alias Moddity.PrinterStatus
+
+  doctest PrinterStatus
+
+  @status_template %{
+    "error" => 0,
+    "job" => %{
+      "progress" => 9,
+      "time_elapsed" => 0
+    },
+    "status" => %{
+      "extruder_target_temperature" => 210.0,
+      "extruder_temperature" => 162.16,
+      "filament" => "OK",
+      "state" => "STATE_IDLE"
+    }
+  }
+
+  test "from_raw includes extruder information" do
+    assert %PrinterStatus{
+      extruder_target_temperature: 210.0,
+      extruder_actual_temperature: 162.16
+    } = PrinterStatus.from_raw(@status_template)
+  end
+
+  test "from_raw includes progress information" do
+    assert %PrinterStatus{
+      job_progress: 9
+    } = PrinterStatus.from_raw(@status_template)
+  end
+
+  test "from_raw handles unknown status messages" do
+    raw = put_in(@status_template, ["status", "state"], "NO_IDEA")
+    assert %PrinterStatus{
+      state: :unknown,
+      state_friendly: "Unknown: NO_IDEA",
+      idle?: false,
+      error: 0
+    } = PrinterStatus.from_raw(raw)
+  end
+
+  test "from_raw handles paused" do
+    raw = put_in(@status_template, ["status", "state"], "STATE_PAUSED")
+    assert %PrinterStatus{
+      state: :paused,
+      state_friendly: "Paused",
+      idle?: false,
+      error: 0
+    } = PrinterStatus.from_raw(raw)
+  end
+
+  test "from_raw handles net failed" do
+    raw = put_in(@status_template, ["status", "state"], "STATE_NET_FAILED")
+    assert %PrinterStatus{
+      state: :net_failed,
+      state_friendly: "Net Failed",
+      idle?: false,
+      error: 0} = PrinterStatus.from_raw(raw)
+  end
+
+  test "from_raw handles mech ready" do
+    raw = put_in(@status_template, ["status", "state"], "STATE_MECH_READY")
+    assert %PrinterStatus{
+      state: :mech_ready,
+      state_friendly: "Mech Ready",
+      idle?: false,
+      error: 0} = PrinterStatus.from_raw(raw)
+  end
+
+  test "from_raw handles unload filament heating" do
+    raw = put_in(@status_template, ["status", "state"], "STATE_REMFIL_HEATING")
+    assert %PrinterStatus{
+      state: :unload_filament_heating,
+      state_friendly: "Unload Filament: Heating",
+      idle?: false,
+      error: 0} = PrinterStatus.from_raw(raw)
+  end
+
+  test "from_raw handles unload filament retracting" do
+    raw = put_in(@status_template, ["status", "state"], "STATE_REMFIL_RETRACTING")
+    assert %PrinterStatus{
+      state: :unload_filament_retracting,
+      state_friendly: "Unload Filament: Retracting",
+      idle?: false,
+      error: 0
+    } = PrinterStatus.from_raw(raw)
+  end
+
+  test "from_raw handles load filament heating" do
+    raw = put_in(@status_template, ["status", "state"], "STATE_LOADFIL_HEATING")
+    assert %PrinterStatus{
+      state: :load_filament_heating,
+      state_friendly: "Load Filament: Heating",
+      idle?: false,
+      error: 0} = PrinterStatus.from_raw(raw)
+  end
+
+  test "from_raw handles load filament extruding" do
+    raw = put_in(@status_template, ["status", "state"], "STATE_LOADFIL_EXTRUDING")
+    assert %PrinterStatus{
+      state: :load_filament_extruding,
+      state_friendly: "Load Filament: Extruding",
+      idle?: false,
+      error: 0} = PrinterStatus.from_raw(raw)
+  end
+
+  test "from_raw handles job queued" do
+    raw = put_in(@status_template, ["status", "state"], "STATE_JOB_QUEUED")
+    assert %PrinterStatus{
+      state: :job_queued,
+      state_friendly: "Job Queued",
+      idle?: false,
+      error: 0} = PrinterStatus.from_raw(raw)
+  end
+
+  test "from_raw handles job prep" do
+    raw = put_in(@status_template, ["status", "state"], "STATE_JOB_PREP")
+    assert %PrinterStatus{
+      state: :job_prep,
+      state_friendly: "Job Prep",
+      idle?: false,
+      error: 0
+    } = PrinterStatus.from_raw(raw)
+  end
+
+  test "from_raw handles job canceled" do
+    raw = put_in(@status_template, ["status", "state"], "STATE_JOB_CANCEL")
+    assert %PrinterStatus{
+      state: :canceled,
+      state_friendly: "Job Canceled",
+      idle?: false,
+      error: 0
+    } = PrinterStatus.from_raw(raw)
+  end
+
+  test "from_raw handles homing z fine" do
+    raw = put_in(@status_template, ["status", "state"], "STATE_HOMING_Z_FINE")
+    assert %PrinterStatus{
+      state: :homing_z_fine,
+      state_friendly: "Calibrating: Z (Fine)",
+      idle?: false,
+      error: 0} = PrinterStatus.from_raw(raw)
+  end
+
+  test "from_raw handles homing z rough" do
+    raw = put_in(@status_template, ["status", "state"], "STATE_HOMING_Z_ROUGH")
+    assert %PrinterStatus{
+      state: :homing_z_rough,
+      state_friendly: "Calibrating: Z (Rough)",
+      idle?: false,
+      error: 0} = PrinterStatus.from_raw(raw)
+  end
+
+  test "from_raw handles homing xy" do
+    raw = put_in(@status_template, ["status", "state"], "STATE_HOMING_XY")
+    assert %PrinterStatus{
+      state: :homing_xy,
+      state_friendly: "Calibrating: XY",
+      idle?: false,
+      error: 0} = PrinterStatus.from_raw(raw)
+  end
+
+  test "from_raw handles heating" do
+    raw = put_in(@status_template, ["status", "state"], "STATE_HOMING_HEATING")
+    assert %PrinterStatus{
+      state: :homing_heating,
+      state_friendly: "Calibrating: Heating",
+      idle?: false,
+      error: 0} = PrinterStatus.from_raw(raw)
+  end
+
+  test "from_raw handles receiving file" do
+    raw = put_in(@status_template, ["status", "state"], "STATE_FILE_RX")
+    assert %PrinterStatus{
+      state: :receiving_file,
+      state_friendly: "Receiving File",
+      idle?: false,
+      error: 0} = PrinterStatus.from_raw(raw)
+  end
+
+  test "from_raw handles exec pause cmd" do
+    raw = put_in(@status_template, ["status", "state"], "STATE_EXEC_PAUSE_CMD")
+    assert %PrinterStatus{
+      state: :pausing,
+      state_friendly: "Pausing",
+      idle?: false,
+      error: 0} = PrinterStatus.from_raw(raw)
+  end
+
+  test "from_raw handles building" do
+    raw = put_in(@status_template, ["status", "state"], "STATE_BUILDING")
+    assert %PrinterStatus{
+      state: :building,
+      state_friendly: "Building",
+      idle?: false,
+      error: 0} = PrinterStatus.from_raw(raw)
+  end
+
+  test "from_raw handles idle" do
+    assert %PrinterStatus{
+      state: :idle,
+      state_friendly: "Idle",
+      idle?: true,
+      error: 0} = PrinterStatus.from_raw(@status_template)
+  end
+end

--- a/test/moddity_test.exs
+++ b/test/moddity_test.exs
@@ -1,8 +1,0 @@
-defmodule ModdityTest do
-  use ExUnit.Case
-  doctest Moddity
-
-  test "greets the world" do
-    assert Moddity.hello() == :world
-  end
-end

--- a/test/test_helper.exs
+++ b/test/test_helper.exs
@@ -1,1 +1,3 @@
 ExUnit.start()
+
+Mox.defmock(Moddity.Backend.Mock, for: Moddity.Backend)


### PR DESCRIPTION
The goal of this PR is to enhance the responsiveness of the driver when there is an action in progress (namely, the send_gcode function call takes a while due to the way that the python script and the elixir application communicate).

In order to support that, the moddity application is more aware of the quality of the state of the printer, not just translating strings to atoms, but understanding which states indicate that the printer is in use, and which indicate that it's idle.

This will allow the UI to update status more accurately, and also to disable new actions while the printer is operating.